### PR TITLE
COMP: Fix build error updating module to support Qt5

### DIFF
--- a/TrackerStabilizer/qSlicerTrackerStabilizerModule.cxx
+++ b/TrackerStabilizer/qSlicerTrackerStabilizerModule.cxx
@@ -26,7 +26,10 @@
 #include "qSlicerTrackerStabilizerModuleWidget.h"
 
 //-----------------------------------------------------------------------------
+#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
+#include <QtPlugin>
 Q_EXPORT_PLUGIN2(qSlicerTrackerStabilizerModule, qSlicerTrackerStabilizerModule);
+#endif
 
 //-----------------------------------------------------------------------------
 /// \ingroup Slicer_QtModules_ExtensionTemplate

--- a/TrackerStabilizer/qSlicerTrackerStabilizerModule.h
+++ b/TrackerStabilizer/qSlicerTrackerStabilizerModule.h
@@ -31,6 +31,9 @@ qSlicerTrackerStabilizerModule
   : public qSlicerLoadableModule
 {
   Q_OBJECT
+#ifdef Slicer_HAVE_QT5
+  Q_PLUGIN_METADATA(IID "org.slicer.modules.loadable.qSlicerLoadableModule/1.0");
+#endif
   Q_INTERFACES(qSlicerLoadableModule);
 
 public:


### PR DESCRIPTION
This commit fixes the following build error:
```
  /tmp/Slicer-TrackerStabilizer/TrackerStabilizer/qSlicerTrackerStabilizerModule.cxx:29:1: error: static assertion failed: Old plugin system used
   Q_EXPORT_PLUGIN2(qSlicerTrackerStabilizerModule, qSlicerTrackerStabilizerModule);
   ^
```
See https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/MigrationGuide#Qt5:_Update_loadable_modules_to_use_new_plugin_macros