### PR TITLE
Adjusted for qt5 compatibility

### DIFF
--- a/TrackerStabilizer/qSlicerTrackerStabilizerModule.cxx
+++ b/TrackerStabilizer/qSlicerTrackerStabilizerModule.cxx
@@ -26,7 +26,13 @@
 #include "qSlicerTrackerStabilizerModuleWidget.h"
 
 //-----------------------------------------------------------------------------
+// Migration VTK7-Qt4-to-VTK8-Qt5
+// Q_EXPORT_PLUGIN2(qSlicerTrackerStabilizerModule, qSlicerTrackerStabilizerModule);
+
+#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
+#include <QtPlugin>
 Q_EXPORT_PLUGIN2(qSlicerTrackerStabilizerModule, qSlicerTrackerStabilizerModule);
+#endif
 
 //-----------------------------------------------------------------------------
 /// \ingroup Slicer_QtModules_ExtensionTemplate

--- a/TrackerStabilizer/qSlicerTrackerStabilizerModule.h
+++ b/TrackerStabilizer/qSlicerTrackerStabilizerModule.h
@@ -30,8 +30,15 @@ class Q_SLICER_QTMODULES_TRACKERSTABILIZER_EXPORT
 qSlicerTrackerStabilizerModule
   : public qSlicerLoadableModule
 {
+  // Migration VTK7-Qt4-to-VTK8-Qt5
+  // Q_OBJECT
+  // Q_INTERFACES(qSlicerLoadableModule);
+
   Q_OBJECT
-  Q_INTERFACES(qSlicerLoadableModule);
+  #ifdef Slicer_HAVE_QT5
+    Q_PLUGIN_METADATA(IID "org.slicer.modules.loadable.qSlicerLoadableModule/1.0");
+  #endif
+    Q_INTERFACES(qSlicerLoadableModule);
 
 public:
 


### PR DESCRIPTION
COMP: Qt5: Fix error: static assertion failed: Old plugin system used

See https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/MigrationGuide/VTK7-Qt4-to-VTK8-Qt5#Qt5:_Update_loadable_modules_to_use_new_plugin_macros